### PR TITLE
fix: install compatible pytorch torchvision

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM continuumio/miniconda3 AS build
 
 ARG PYTHONNOUSERSITE=True
 
-RUN conda create --name triton-conda-env python=3.8 scikit-learn pytorch torchvision cpuonly -c conda-forge -c pytorch
+RUN conda create --name triton-conda-env python=3.8 scikit-learn pytorch==1.11.0 torchvision==0.12.0 cpuonly -c conda-forge -c pytorch
 
 # Instill triton-python-model
 ARG TRITON_PYTHON_MODEL_VERSION

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM continuumio/miniconda3 AS build
 
 ARG PYTHONNOUSERSITE=True
 
-RUN conda create --name triton-conda-env python=3.8 scikit-learn pytorch torchvision -c conda-forge -c pytorch
+RUN conda create --name triton-conda-env python=3.8 scikit-learn pytorch==1.11.0 torchvision==0.12.0 -c conda-forge -c pytorch
 
 # Instill triton-python-model
 ARG TRITON_PYTHON_MODEL_VERSION

--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ From [Triton python backend](https://github.com/triton-inference-server/python_b
 We maintain Dockerfiles for Instill AI's official [conda](https://docs.conda.io/en/latest/) environment for Triton python-backend. In the conda environment, we use Python 3.8 and install packages
 - [scikit-learn==1.1.1](https://github.com/scikit-learn/scikit-learn)
 - [Pillow==9.1.1](https://github.com/python-pillow/Pillow)
-- [PyTorch==1.10.2](https://github.com/pytorch/pytorch)
+- [PyTorch==1.11.0](https://github.com/pytorch/pytorch)
+- [torchvision=0.12.0](https://pytorch.org/vision/stable/index.html)
 - triton-python-model
+
+Please read [here](https://github.com/pytorch/pytorch/wiki/PyTorch-Versions) for the PyTorch compatible domain libraries.
 
 ## License
 


### PR DESCRIPTION
Because

- install PyTorch and torchvision according to the [PyTorch support matrix](https://github.com/pytorch/pytorch/wiki/PyTorch-Versions#domain-version-compatibility-matrix-for-pytorch)

This commit

- install PyTorch with version `1.11.0`
- install torchvision with version `0.12.0`


<br class="Apple-interchange-newline">
