### PR TITLE
chore: install torch & torchvision via pip for m1

### DIFF
--- a/Dockerfile.m1
+++ b/Dockerfile.m1
@@ -2,17 +2,17 @@ FROM --platform=$BUILDPLATFORM continuumio/miniconda3 AS build
 
 ARG PYTHONNOUSERSITE=True
 
-RUN conda create --name triton-conda-env python=3.8 scikit-learn pytorch torchvision -c conda-forge -c pytorch-nightly
+RUN conda create --name triton-conda-env python=3.8 scikit-learn
 
 # Instill triton-python-model
 ARG TRITON_PYTHON_MODEL_VERSION
 ADD /triton_python_model /tmp/triton_python_model
-ADD requirements.txt /tmp/
-ADD setup.py /tmp/
+ADD requirements-m1.txt /tmp
+ADD setup.py /tmp
 RUN conda run -n triton-conda-env \
-  python -m pip install -r /tmp/requirements.txt
+  python -m pip install -r /tmp/requirements-m1.txt
 RUN conda run -n triton-conda-env \
-  python -m pip install --no-deps /tmp
+  python -m pip install --no-deps -r /tmp/requirements-m1.txt
 
 # Install conda-pack
 RUN conda install conda-pack=0.7.0 -c conda-forge

--- a/requirements-m1.txt
+++ b/requirements-m1.txt
@@ -1,0 +1,6 @@
+numpy>=1.21.2
+packaging>=21.3
+setuptools>=58.0.4
+transformers
+torch==1.11.0
+torchvision==0.12.0


### PR DESCRIPTION
Because

- we want to install `PyTorch==0.11.0` and `torchvision==0.12.0` (compatible versions, see [compatibility matrix](https://github.com/pytorch/pytorch/wiki/PyTorch-Versions#domain-version-compatibility-matrix-for-pytorch)) for M1, but these packages are not available from the Conda channels. See errors below.
```bash
#8 22.66 PackagesNotFoundError: The following packages are not available from current channels:
#8 22.66 
#8 22.66   - pytorch==1.11.0
#8 22.66   - torchvision==0.12.0
#8 22.66 
#8 22.66 Current channels:
#8 22.66 
#8 22.66   - https://conda.anaconda.org/conda-forge/linux-aarch64
#8 22.66   - https://conda.anaconda.org/conda-forge/noarch
#8 22.66   - https://conda.anaconda.org/pytorch/linux-aarch64
#8 22.66   - https://conda.anaconda.org/pytorch/noarch
#8 22.66   - https://repo.anaconda.com/pkgs/main/linux-aarch64
#8 22.66   - https://repo.anaconda.com/pkgs/main/noarch
#8 22.66   - https://repo.anaconda.com/pkgs/r/linux-aarch64
#8 22.66   - https://repo.anaconda.com/pkgs/r/noarch
#8 22.66 
#8 22.66 To search for alternate channels that may provide the conda package you're
#8 22.66 looking for, navigate to
#8 22.66 
#8 22.66     https://anaconda.org
#8 22.66 
#8 22.66 and use the search bar at the top of the page.
#8 22.66 
``` 

This commit

- install PyTorch and torchvision via pip
